### PR TITLE
More fixes to 'make distcheck'

### DIFF
--- a/src/gudev/Makefile.am
+++ b/src/gudev/Makefile.am
@@ -46,6 +46,11 @@ nodist_libgudev_1_0_la_SOURCES = \
 	gudevenumtypes.h \
 	gudevenumtypes.c
 
+CLEANFILES += \
+	gudevmarshal.h \
+	gudevmarshal.c \
+	gudevenumtypes.c
+
 BUILT_SOURCES = \
 	$(nodist_libgudev_1_0_la_SOURCES)
 

--- a/src/keymap/Makefile.am
+++ b/src/keymap/Makefile.am
@@ -41,7 +41,8 @@ TESTS = \
 CLEANFILES = \
 	keys.txt \
 	keys-from-name.gperf \
-	keyboard-force-release.sh
+	keyboard-force-release.sh \
+	$(nodist_keymap_SOURCES)
 
 EXTRA_DIST = \
 	check-keymaps.sh \

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -1,8 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 AM_CPPFLAGS = \
-	-DVERSION \
-	-DCLONE_NEWNS \
+	-DVERSION=\"@VERSION@\" \
         -I $(top_srcdir)/src/libudev \
         -I $(top_srcdir)/src/udev
 

--- a/src/test/test-libudev.c
+++ b/src/test/test-libudev.c
@@ -489,7 +489,7 @@ int main(int argc, char *argv[])
                         printf("--debug --syspath= --subsystem= --help\n");
                         goto out;
                 case 'V':
-                        printf("%i\n", VERSION);
+                        printf("%s\n", VERSION);
                         goto out;
                 default:
                         goto out;

--- a/src/test/test-udev.c
+++ b/src/test/test-udev.c
@@ -40,6 +40,11 @@
 static inline int unshare (int x) { return syscall(SYS_unshare, x); }
 #endif
 
+#ifndef _USE_GNU
+/* Make sure CLONE_NEWNS macro is available */
+#include <linux/sched.h>
+#endif
+
 void udev_main_log(struct udev *udev, int priority,
                    const char *file, int line, const char *fn,
                    const char *format, va_list args) {}
@@ -50,11 +55,11 @@ static int fake_filesystems(void) {
                 const char *target;
                 const char *error;
         } fakefss[] = {
-                { "test/sys", "/sys",                   "failed to mount test /sys" },
-                { "test/dev", "/dev",                   "failed to mount test /dev" },
-                { "test/run", "/run",                   "failed to mount test /run" },
-                { "test/run", "/etc/udev/rules.d",      "failed to mount empty /etc/udev/rules.d" },
-                { "test/run", "/usr/lib/udev/rules.d",  "failed to mount empty /usr/lib/udev/rules.d" },
+                { "../test/sys", "/sys",                   "failed to mount test /sys" },
+                { "../test/dev", "/dev",                   "failed to mount test /dev" },
+                { "../test/run", "/run",                   "failed to mount test /run" },
+                { "../test/run", "/etc/udev/rules.d",      "failed to mount empty /etc/udev/rules.d" },
+                { "../test/run", "/usr/lib/udev/rules.d",  "failed to mount empty /usr/lib/udev/rules.d" },
         };
         unsigned int i;
         int err;
@@ -62,13 +67,13 @@ static int fake_filesystems(void) {
         err = unshare(CLONE_NEWNS);
         if (err < 0) {
                 err = -errno;
-                fprintf(stderr, "failed to call unshare(): %m\n");
+                perror("failed to call unshare()");
                 goto out;
         }
 
         if (mount(NULL, "/", NULL, MS_PRIVATE|MS_REC, NULL) < 0) {
                 err = -errno;
-                fprintf(stderr, "failed to mount / as private: %m\n");
+                perror("failed to mount / as private");
                 goto out;
         }
 
@@ -76,7 +81,7 @@ static int fake_filesystems(void) {
                 err = mount(fakefss[i].src, fakefss[i].target, NULL, MS_BIND, NULL);
                 if (err < 0) {
                         err = -errno;
-                        fprintf(stderr, "%s %m", fakefss[i].error);
+                        perror(fakefss[i].error);
                         return err;
                 }
         }
@@ -104,7 +109,7 @@ int main(int argc, char *argv[])
         udev = udev_new();
         if (udev == NULL)
                 exit(EXIT_FAILURE);
-        log_debug("version %i\n", VERSION);
+        log_debug("version %s\n", VERSION);
         label_init("/dev");
 
         sigprocmask(SIG_SETMASK, NULL, &sigmask_orig);

--- a/test/udev-test.pl
+++ b/test/udev-test.pl
@@ -20,11 +20,12 @@
 use warnings;
 use strict;
 
-my $udev_bin            = "./test-udev";
+my $udev_bin            = "../src/test/test-udev";
 my $valgrind            = 0;
 my $udev_bin_valgrind   = "valgrind --tool=memcheck --leak-check=yes --quiet $udev_bin";
-my $udev_dev            = "test/dev";
-my $udev_run            = "test/run";
+my $udev_sys            = "../test/sys";
+my $udev_dev            = "../test/dev";
+my $udev_run            = "../test/run";
 my $udev_rules_dir      = "$udev_run/udev/rules.d";
 my $udev_rules          = "$udev_rules_dir/udev-test.rules";
 
@@ -1521,6 +1522,7 @@ if ($list[0]) {
 print "$error errors occured\n\n";
 
 # cleanup
+system("rm", "-rf", "$udev_sys");
 system("rm", "-rf", "$udev_dev");
 system("rm", "-rf", "$udev_run");
 


### PR DESCRIPTION
With the latest master pull (081d682b263decd8d4b60a8351de30c0e563f751), I see the error "Can't exec "./test-udev: No such file or directory" when running 'sudo make distcheck".   I had some free time so I looked into fixing it.

This pull request is the result of that fix.  It also fixes the following issues:
- make failing distcheck due to nonempty build directory
- Incorrect definition for CLONE_NEWNS macro in src/test/Makefile.am
- Updated sources to pull CLONE_NEWNS from linux/sched.h when _USE_GNU is not defined.
- Corrected paths in various source files and perl script.
- Changed  fprintf() calls that had the %m format specifier to perror() calls (GNUism)
- Updated the test-udev.pl script to delete the test  /sys directory (helped address the previously mentioned "nonempty build directory" problem)

I also changed how the VERSION macro is handled in src/test/Makefile.am.  Originally it was defined with a default value of 1.  It now is assigned to the string form of @VERSION@.  Affected sources were also updated to use %s for version instead of %i in format strings.

Thanks!
