### PR TITLE
Fix make distcheck error: "gtk-doc must be installed and enabled in order to make dist"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
+DISTCHECK_CONFIGURE_FLAGS=--enable-gtk-doc
 
 SUBDIRS = \
 	src \

--- a/configure.ac
+++ b/configure.ac
@@ -237,8 +237,6 @@ AS_IF([test "x$enable_gtk_doc" = "xyes" -a "x$XSLTPROC" = x], [
 	AC_MSG_ERROR([*** GTK doc requested but xsltproc not found])
 ])
 
-DISTCHECK_CONFIGURE_FLAGS=--enable-gtk-doc
-
 # ------------------------------------------------------------------------------
 have_manpages=no
 AC_ARG_ENABLE(manpages, AS_HELP_STRING([--disable-manpages], [disable manpages]))


### PR DESCRIPTION
This error occurs because automake does not detect the DISTCHECK_CONFIGURE_FLAGS variable in configure.ac.  Automake manual confirms that DISTCHECK_CONFIGURE_FLAGS should be defined in top-level Makefile.am instead of configure.ac.  This branch corrects that issue.
