### PR TITLE
Make binaries report udev version compatibility version instead of eudev...

### DIFF
--- a/src/udev/Makefile.am
+++ b/src/udev/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
 	-DUDEV_CONF_DIR=\"$(udevconfdir)\" \
 	-DUDEV_RULES_DIR=\"$(udevrulesdir)\" \
 	-DUDEV_LIBEXEC_DIR=\"$(udevlibexecdir)\" \
+	-DUDEV_VERSION=\"$(UDEV_VERSION)\" \
 	-I $(top_srcdir)/src/libudev
 
 sbin_PROGRAMS = \

--- a/src/udev/udevadm-info.c
+++ b/src/udev/udevadm-info.c
@@ -432,7 +432,7 @@ static int uinfo(struct udev *udev, int argc, char *argv[])
                         export_prefix = optarg;
                         break;
                 case 'V':
-                        printf("%s\n", VERSION);
+                        printf("%s\n", UDEV_VERSION);
                         goto exit;
                 case 'h':
                         printf("%s\n", usage);

--- a/src/udev/udevadm.c
+++ b/src/udev/udevadm.c
@@ -34,7 +34,7 @@ void udev_main_log(struct udev *udev, int priority,
 
 static int adm_version(struct udev *udev, int argc, char *argv[])
 {
-        printf("%s\n", VERSION);
+        printf("%s\n", UDEV_VERSION);
         return 0;
 }
 

--- a/src/udev/udevd.c
+++ b/src/udev/udevd.c
@@ -1141,7 +1141,7 @@ int main(int argc, char *argv[])
                                "\n");
                         goto exit;
                 case 'V':
-                        printf("%s\n", VERSION);
+                        printf("%s\n", UDEV_VERSION);
                         goto exit;
                 default:
                         goto exit;


### PR DESCRIPTION
... version

Software such as dracut performs a sanity check on udev by querying the
udev tools for the version. Reporting the eudev version causes this
check to fail, so we resort to reporting the udev compatibility
versionj.

Signed-off-by: Richard Yao ryao@gentoo.org
