### PR TITLE
add --root to support generating hwdb in offsetted rootfs

### DIFF
--- a/src/libudev/conf-files.h
+++ b/src/libudev/conf-files.h
@@ -25,7 +25,13 @@
 
 #include "macro.h"
 
-int conf_files_list(char ***strv, const char *suffix, const char *dir, ...);
-int conf_files_list_strv(char ***strv, const char *suffix, const char **dirs);
+int conf_files_list(char ***strv,
+                    const char *prefix,
+                    const char *suffix,
+                    const char *dir, ...);
+int conf_files_list_strv(char ***strv,
+                         const char *prefix,
+                         const char *suffix,
+                         const char **dirs);
 
 #endif

--- a/src/udev/udev-rules.c
+++ b/src/udev/udev-rules.c
@@ -1639,7 +1639,7 @@ struct udev_rules *udev_rules_new(struct udev *udev, int resolve_names)
                 return udev_rules_unref(rules);
         udev_rules_check_timestamp(rules);
 
-        r = conf_files_list_strv(&files, ".rules", (const char **)rules->dirs);
+        r = conf_files_list_strv(&files, NULL, ".rules", (const char **)rules->dirs);
         if (r < 0) {
                 log_error("failed to enumerate rules files: %s\n", strerror(-r));
                 return udev_rules_unref(rules);


### PR DESCRIPTION
Introduce `--root` option to make users run udevadm on rootfs not
mounted as /

Ease the life of distribution packagers.
