### PR TITLE
Clean up the string functions

### DIFF
--- a/src/libudev/libudev-util.c
+++ b/src/libudev/libudev-util.c
@@ -317,17 +317,17 @@ void util_remove_trailing_chars(char *path, char c)
  */
 size_t util_strpcpy(char **dest, size_t size, const char *src)
 {
-        char *dstend = *dest+(size-1);
+        char *dstend = *dest + (size - 1);
         
         if (!size) return 0; /*Nothing to do if size is 0*/
         
-        *dest=memccpy(*dest,src,'\0',size);
+        *dest = memccpy(*dest, src, '\0', size);
         
         if (*dest) {/*Terminator character found*/
                 (*dest)--; /*memccpy points to the element after the one with '\0'*/
-                return (dstend - *dest)+1;/*For some odd reason they are not taking into account the \0 in the capacity...*/
+                return (dstend - *dest) + 1;/*For some odd reason they are not taking into account the \0 in the capacity...*/
         } else {
-                *(*dest=dstend)='\0'; /*Restore dest and add terminator*/
+                *(*dest = dstend) = '\0'; /*Restore dest and add terminator*/
                 return 0; /*But here they do*/
         }
 }
@@ -345,7 +345,7 @@ size_t util_strpcpyf(char **dest, size_t size, const char *src, ...)
                 *dest += i;
                 size -= i;
         } else {
-                *dest += size-1;
+                *dest += size - 1;
                 size = 0;
         }
         va_end(va);


### PR DESCRIPTION
This is the cleaned version of the string functions, there is no necessity for an assembly version if it is provided by the libc.

It avoids two evaluations of src in util_strpcpy clean (one in strlen and the other in mempcpy) and shortcircuits the case when size is 0 so the if afterwards can be cleaner. 

It also cleans the implementation of util_strscpy and util_strscpyl by passing a reference to the copy of the pointer already passed as argument.

It introduces util_strpcpyv so the main loop into util_strscpyl and util_strpcpyl can be merged.

It shortcircuits the cases when size is 0.

It fixes a buffer overflow in util_strpcpyf

It finally ensures the MIT license of murmurhash2 is respected by adding the copyright marking.
