### PR TITLE
replace hardcoded /run with RUN_DIR macro

### DIFF
--- a/src/collect/collect.c
+++ b/src/collect/collect.c
@@ -414,7 +414,7 @@ int main(int argc, char **argv)
         if (debug)
                 fprintf(stderr, "Using checkpoint '%s'\n", checkpoint);
 
-        strscpyl(tmpdir, sizeof(tmpdir), "/run/udev/collect", NULL);
+        strscpyl(tmpdir, sizeof(tmpdir), RUN_DIR "/udev/collect", NULL);
         fd = prepare(tmpdir, checkpoint);
         if (fd < 0) {
                 ret = 3;

--- a/src/libudev/libudev-device-private.c
+++ b/src/libudev/libudev-device-private.c
@@ -38,7 +38,7 @@ static void udev_device_tag(struct udev_device *dev, const char *tag, bool add)
         id = udev_device_get_id_filename(dev);
         if (id == NULL)
                 return;
-        strscpyl(filename, sizeof(filename), "/run/udev/tags/", tag, "/", id, NULL);
+        strscpyl(filename, sizeof(filename), RUN_DIR "/udev/tags/", tag, "/", id, NULL);
 
         if (add) {
                 int fd;
@@ -116,7 +116,7 @@ int udev_device_update_db(struct udev_device *udev_device)
                 return -1;
 
         has_info = device_has_info(udev_device);
-        strscpyl(filename, sizeof(filename), "/run/udev/data/", id, NULL);
+        strscpyl(filename, sizeof(filename), RUN_DIR "/udev/data/", id, NULL);
 
         /* do not store anything for otherwise empty devices */
         if (!has_info &&
@@ -186,7 +186,7 @@ int udev_device_delete_db(struct udev_device *udev_device)
         id = udev_device_get_id_filename(udev_device);
         if (id == NULL)
                 return -1;
-        strscpyl(filename, sizeof(filename), "/run/udev/data/", id, NULL);
+        strscpyl(filename, sizeof(filename), RUN_DIR "/udev/data/", id, NULL);
         unlink(filename);
         return 0;
 }

--- a/src/libudev/libudev-device.c
+++ b/src/libudev/libudev-device.c
@@ -527,7 +527,7 @@ int udev_device_read_db(struct udev_device *udev_device, const char *dbfile)
                 id = udev_device_get_id_filename(udev_device);
                 if (id == NULL)
                         return -1;
-                strscpyl(filename, sizeof(filename), "/run/udev/data/", id, NULL);
+                strscpyl(filename, sizeof(filename), RUN_DIR "/udev/data/", id, NULL);
                 dbfile = filename;
         }
 

--- a/src/libudev/libudev-enumerate.c
+++ b/src/libudev/libudev-enumerate.c
@@ -797,7 +797,7 @@ static int scan_devices_tags(struct udev_enumerate *udev_enumerate)
                 struct dirent *dent;
                 char path[UTIL_PATH_SIZE];
 
-                strscpyl(path, sizeof(path), "/run/udev/tags/", udev_list_entry_get_name(list_entry), NULL);
+                strscpyl(path, sizeof(path), RUN_DIR "/udev/tags/", udev_list_entry_get_name(list_entry), NULL);
                 dir = opendir(path);
                 if (dir == NULL)
                         continue;

--- a/src/libudev/libudev-queue-private.c
+++ b/src/libudev/libudev-queue-private.c
@@ -111,8 +111,8 @@ void udev_queue_export_cleanup(struct udev_queue_export *udev_queue_export)
 {
         if (udev_queue_export == NULL)
                 return;
-        unlink("/run/udev/queue.tmp");
-        unlink("/run/udev/queue.bin");
+        unlink(RUN_DIR "/udev/queue.tmp");
+        unlink(RUN_DIR "/udev/queue.bin");
 }
 
 static int skip_to(FILE *file, long offset)
@@ -220,7 +220,7 @@ static int rebuild_queue_file(struct udev_queue_export *udev_queue_export)
         }
 
         /* create new queue file */
-        new_queue_file = fopen("/run/udev/queue.tmp", "w+e");
+        new_queue_file = fopen(RUN_DIR "/udev/queue.tmp", "w+e");
         if (new_queue_file == NULL)
                 goto error;
         seqnum = udev_queue_export->seqnum_max;
@@ -256,7 +256,7 @@ static int rebuild_queue_file(struct udev_queue_export *udev_queue_export)
                 goto error;
 
         /* rename the new file on top of the old one */
-        if (rename("/run/udev/queue.tmp", "/run/udev/queue.bin") != 0)
+        if (rename(RUN_DIR "/udev/queue.tmp", RUN_DIR "/udev/queue.bin") != 0)
                 goto error;
 
         if (udev_queue_export->queue_file != NULL)

--- a/src/libudev/libudev-queue.c
+++ b/src/libudev/libudev-queue.c
@@ -220,7 +220,7 @@ static FILE *open_queue_file(struct udev_queue *udev_queue, unsigned long long i
 {
         FILE *queue_file;
 
-        queue_file = fopen("/run/udev/queue.bin", "re");
+        queue_file = fopen(RUN_DIR "/udev/queue.bin", "re");
         if (queue_file == NULL)
                 return NULL;
 

--- a/src/libudev/log.c
+++ b/src/libudev/log.c
@@ -184,7 +184,7 @@ void log_close_journal(void) {
 static int log_open_journal(void) {
         union sockaddr_union sa = {
                 .un.sun_family = AF_UNIX,
-                .un.sun_path = "/run/systemd/journal/socket",
+                .un.sun_path = RUN_DIR "/systemd/journal/socket",
         };
         int r;
 

--- a/src/udev/udev-ctrl.c
+++ b/src/udev/udev-ctrl.c
@@ -96,7 +96,7 @@ struct udev_ctrl *udev_ctrl_new_from_fd(struct udev *udev, int fd)
         setsockopt(uctrl->sock, SOL_SOCKET, SO_PASSCRED, &on, sizeof(on));
 
         uctrl->saddr.sun_family = AF_LOCAL;
-        strscpy(uctrl->saddr.sun_path, sizeof(uctrl->saddr.sun_path), "/run/udev/control");
+        strscpy(uctrl->saddr.sun_path, sizeof(uctrl->saddr.sun_path), RUN_DIR "/udev/control");
         uctrl->addrlen = offsetof(struct sockaddr_un, sun_path) + strlen(uctrl->saddr.sun_path);
         return uctrl;
 }

--- a/src/udev/udev-node.c
+++ b/src/udev/udev-node.c
@@ -189,7 +189,7 @@ static void link_update(struct udev_device *dev, const char *slink, bool add)
         char buf[UTIL_PATH_SIZE];
 
         util_path_encode(slink + strlen("/dev"), name_enc, sizeof(name_enc));
-        strscpyl(dirname, sizeof(dirname), "/run/udev/links/", name_enc, NULL);
+        strscpyl(dirname, sizeof(dirname), RUN_DIR "/udev/links/", name_enc, NULL);
         strscpyl(filename, sizeof(filename), dirname, "/", udev_device_get_id_filename(dev), NULL);
 
         if (!add && unlink(filename) == 0)

--- a/src/udev/udev-rules.c
+++ b/src/udev/udev-rules.c
@@ -1618,7 +1618,7 @@ struct udev_rules *udev_rules_new(struct udev *udev, int resolve_names)
 
         rules->dirs = strv_new(UDEV_CONF_DIR "/rules.d",
                                UDEV_RULES_DIR,
-                               "/run/udev/rules.d",
+                               RUN_DIR "/udev/rules.d",
                                UDEV_LIBEXEC_DIR "/rules.d",
 #ifdef HAVE_SPLIT_USR
                                "/lib/udev/rules.d",
@@ -2652,7 +2652,7 @@ int udev_rules_apply_static_dev_perms(struct udev_rules *rules)
                                 STRV_FOREACH(t, tags) {
                                         _cleanup_free_ char *unescaped_filename = NULL;
 
-                                        strscpyl(tags_dir, sizeof(tags_dir), "/run/udev/static_node-tags/", *t, "/", NULL);
+                                        strscpyl(tags_dir, sizeof(tags_dir), RUN_DIR "/udev/static_node-tags/", *t, "/", NULL);
                                         r = mkdir_p(tags_dir, 0755);
                                         if (r < 0) {
                                                 log_error("failed to create %s: %s\n", tags_dir, strerror(-r));
@@ -2718,9 +2718,9 @@ finish:
         if (f) {
                 fflush(f);
                 fchmod(fileno(f), 0644);
-                if (ferror(f) || rename(path, "/run/udev/static_node-tags") < 0) {
+                if (ferror(f) || rename(path, RUN_DIR "/udev/static_node-tags") < 0) {
                         r = -errno;
-                        unlink("/run/udev/static_node-tags");
+                        unlink(RUN_DIR "/udev/static_node-tags");
                         unlink(path);
                 }
                 fclose(f);

--- a/src/udev/udev-watch.c
+++ b/src/udev/udev-watch.c
@@ -52,13 +52,13 @@ void udev_watch_restore(struct udev *udev)
         if (inotify_fd < 0)
                 return;
 
-        if (rename("/run/udev/watch", "/run/udev/watch.old") == 0) {
+        if (rename(RUN_DIR "/udev/watch", RUN_DIR "/udev/watch.old") == 0) {
                 DIR *dir;
                 struct dirent *ent;
 
-                dir = opendir("/run/udev/watch.old");
+                dir = opendir(RUN_DIR "/udev/watch.old");
                 if (dir == NULL) {
-                        log_error("unable to open old watches dir /run/udev/watch.old; old watches will not be restored: %m");
+                        log_error("unable to open old watches dir " RUN_DIR "/udev/watch.old; old watches will not be restored: %m");
                         return;
                 }
 
@@ -87,10 +87,10 @@ unlink:
                 }
 
                 closedir(dir);
-                rmdir("/run/udev/watch.old");
+                rmdir(RUN_DIR "/udev/watch.old");
 
         } else if (errno != ENOENT) {
-                log_error("unable to move watches dir /run/udev/watch; old watches will not be restored: %m");
+                log_error("unable to move watches dir " RUN_DIR "/udev/watch; old watches will not be restored: %m");
         }
 }
 
@@ -111,7 +111,7 @@ void udev_watch_begin(struct udev *udev, struct udev_device *dev)
                 return;
         }
 
-        snprintf(filename, sizeof(filename), "/run/udev/watch/%d", wd);
+        snprintf(filename, sizeof(filename), RUN_DIR "/udev/watch/%d", wd);
         mkdir_parents(filename, 0755);
         unlink(filename);
         r = symlink(udev_device_get_id_filename(dev), filename);
@@ -136,7 +136,7 @@ void udev_watch_end(struct udev *udev, struct udev_device *dev)
         log_debug("removing watch on '%s'\n", udev_device_get_devnode(dev));
         inotify_rm_watch(inotify_fd, wd);
 
-        snprintf(filename, sizeof(filename), "/run/udev/watch/%d", wd);
+        snprintf(filename, sizeof(filename), RUN_DIR "/udev/watch/%d", wd);
         unlink(filename);
 
         udev_device_set_watch_handle(dev, -1);
@@ -151,7 +151,7 @@ struct udev_device *udev_watch_lookup(struct udev *udev, int wd)
         if (inotify_fd < 0 || wd < 0)
                 return NULL;
 
-        snprintf(filename, sizeof(filename), "/run/udev/watch/%d", wd);
+        snprintf(filename, sizeof(filename), RUN_DIR "/udev/watch/%d", wd);
         len = readlink(filename, device, sizeof(device));
         if (len <= 0 || (size_t)len == sizeof(device))
                 return NULL;

--- a/src/udev/udevadm-info.c
+++ b/src/udev/udevadm-info.c
@@ -231,33 +231,33 @@ static void cleanup_db(struct udev *udev)
 {
         DIR *dir;
 
-        unlink("/run/udev/queue.bin");
+        unlink(RUN_DIR "/udev/queue.bin");
 
-        dir = opendir("/run/udev/data");
+        dir = opendir(RUN_DIR "/udev/data");
         if (dir != NULL) {
                 cleanup_dir(dir, S_ISVTX, 1);
                 closedir(dir);
         }
 
-        dir = opendir("/run/udev/links");
+        dir = opendir(RUN_DIR "/udev/links");
         if (dir != NULL) {
                 cleanup_dir(dir, 0, 2);
                 closedir(dir);
         }
 
-        dir = opendir("/run/udev/tags");
+        dir = opendir(RUN_DIR "/udev/tags");
         if (dir != NULL) {
                 cleanup_dir(dir, 0, 2);
                 closedir(dir);
         }
 
-        dir = opendir("/run/udev/static_node-tags");
+        dir = opendir(RUN_DIR "/udev/static_node-tags");
         if (dir != NULL) {
                 cleanup_dir(dir, 0, 2);
                 closedir(dir);
         }
 
-        dir = opendir("/run/udev/watch");
+        dir = opendir(RUN_DIR "/udev/watch");
         if (dir != NULL) {
                 cleanup_dir(dir, 0, 1);
                 closedir(dir);

--- a/src/udev/udevadm-settle.c
+++ b/src/udev/udevadm-settle.c
@@ -152,8 +152,8 @@ static int adm_settle(struct udev *udev, int argc, char *argv[])
         if (pfd[0].fd < 0) {
                 log_error("inotify_init failed: %m\n");
         } else {
-                if (inotify_add_watch(pfd[0].fd, "/run/udev" , IN_MOVED_TO) < 0) {
-                        log_error("watching /run/udev failed\n");
+                if (inotify_add_watch(pfd[0].fd, RUN_DIR "/udev" , IN_MOVED_TO) < 0) {
+                        log_error("watching " RUN_DIR "/udev failed\n");
                         close(pfd[0].fd);
                         pfd[0].fd = -1;
                 }

--- a/src/udev/udevd.c
+++ b/src/udev/udevd.c
@@ -1033,7 +1033,7 @@ int main(int argc, char *argv[])
         }
         umask(022);
 
-        mkdir("/run/udev", 0755);
+        mkdir(RUN_DIR "/udev", 0755);
 
         dev_setup(NULL);
         static_dev_create_from_modules(udev);
@@ -1146,10 +1146,10 @@ int main(int argc, char *argv[])
         inotify_add_watch(fd_inotify, UDEV_CONF_DIR "/rules.d",
                           IN_DELETE | IN_MOVE | IN_CLOSE_WRITE);
 
-        if (access("/run/udev/rules.d", F_OK) < 0) {
-                mkdir_p("/run/udev/rules.d", 0755);
+        if (access(RUN_DIR "/udev/rules.d", F_OK) < 0) {
+                mkdir_p(RUN_DIR "/udev/rules.d", 0755);
         }
-        inotify_add_watch(fd_inotify, "/run/udev/rules.d",
+        inotify_add_watch(fd_inotify, RUN_DIR "/udev/rules.d",
                           IN_DELETE | IN_MOVE | IN_CLOSE_WRITE);
 
         udev_watch_restore(udev);

--- a/test/test-udev.c
+++ b/test/test-udev.c
@@ -58,7 +58,7 @@ static int fake_filesystems(void) {
         } fakefss[] = {
                 { "test/sys", "/sys",                   "failed to mount test /sys" },
                 { "test/dev", "/dev",                   "failed to mount test /dev" },
-                { "test/run", "/run",                   "failed to mount test /run" },
+                { "test/run", RUN_DIR,                   "failed to mount test " RUN_DIR },
                 { "test/run", "/etc/udev/rules.d",      "failed to mount empty /etc/udev/rules.d" },
                 { "test/run", "/lib/udev/rules.d",      "failed to mount empty /lib/udev/rules.d" },
         };


### PR DESCRIPTION
to use it, pass -DRUN_DIR="/var/run" in your CFLAGS.
optimally this should be set by autoconf to a default value if not
specified, and allowed to be overridden by a configure option,
for example --rundir=/var/run .

adresses #76

someone that knows his way around autoconf should look at the autoconf part of this, thanks.