### PR TITLE
Handle -1 return from sysconf(_SC_GET{PW,GR}_R_SIZE_MAX)

### DIFF
--- a/src/libudev/libudev-util.c
+++ b/src/libudev/libudev-util.c
@@ -84,8 +84,11 @@ uid_t util_lookup_user(struct udev *udev, const char *user)
         struct passwd *pw;
         uid_t uid;
         size_t buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
-        char *buf = alloca(buflen);
+        char *buf;
 
+        if (buflen == -1)
+                buflen = 1024;
+        buf = alloca(buflen);
         if (streq(user, "root"))
                 return 0;
         uid = strtoul(user, &endptr, 10);
@@ -111,6 +114,8 @@ gid_t util_lookup_group(struct udev *udev, const char *group)
         size_t buflen = sysconf(_SC_GETGR_R_SIZE_MAX);
         char *buf = NULL;
 
+        if (buflen == -1)
+                buflen = 1024;
         if (streq(group, "root"))
                 return 0;
         gid = strtoul(group, &endptr, 10);


### PR DESCRIPTION
POSIX says:

```
Note that sysconf(_SC_GETGR_R_SIZE_MAX) may return -1 if there is no
hard limit on the size of the buffer needed to store all the groups
returned.
```

The example from POSIX uses a default buffer size of 1024 in that case.

Also, correct _SC_GETPW_R_SIZE_MAX to _SC_GETGR_R_SIZE_MAX in util_lookup_group.
