### PR TITLE
fixed ucred compile warnings

### DIFF
--- a/src/accelerometer/Makefile.am
+++ b/src/accelerometer/Makefile.am
@@ -1,6 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 AM_CPPFLAGS = \
+	-D_GNU_SOURCE \
 	-I $(top_srcdir)/src/libudev \
 	-I $(top_srcdir)/src/udev
 

--- a/src/ata_id/Makefile.am
+++ b/src/ata_id/Makefile.am
@@ -1,6 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 AM_CPPFLAGS = \
+	-D_GNU_SOURCE \
 	-I $(top_srcdir)/src/libudev \
 	-I $(top_srcdir)/src/udev
 

--- a/src/cdrom_id/Makefile.am
+++ b/src/cdrom_id/Makefile.am
@@ -1,6 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 AM_CPPFLAGS = \
+	-D_GNU_SOURCE \
 	-I $(top_srcdir)/src/libudev \
 	-I $(top_srcdir)/src/udev
 

--- a/src/collect/Makefile.am
+++ b/src/collect/Makefile.am
@@ -1,6 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 AM_CPPFLAGS = \
+	-D_GNU_SOURCE \
 	-I $(top_srcdir)/src/libudev \
 	-I $(top_srcdir)/src/udev
 

--- a/src/scsi_id/Makefile.am
+++ b/src/scsi_id/Makefile.am
@@ -2,6 +2,7 @@ ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 AM_CPPFLAGS = \
 	-DVERSION \
+	-D_GNU_SOURCE \
 	-I $(top_srcdir)/src/libudev \
 	-I $(top_srcdir)/src/udev
 


### PR DESCRIPTION
modified:   src/accelerometer/Makefile.am
modified:   src/ata_id/Makefile.am
modified:   src/cdrom_id/Makefile.am
modified:   src/collect/Makefile.am
modified:   src/scsi_id/Makefile.am
Adding -D_GNU_SOURCE flag incorporates ucred def in header files
so that 'ucred undeclared' warning do not occur during compilation
against glibc.
