### PR TITLE
fixed gcc warnings that call returns not checked

### DIFF
--- a/src/udev/udev-node.c
+++ b/src/udev/udev-node.c
@@ -286,8 +286,13 @@ static int node_permissions_apply(struct udev_device *dev, bool apply,
 
                 if ((stats.st_mode & 0777) != (mode & 0777) || stats.st_uid != uid || stats.st_gid != gid) {
                         log_debug("set permissions %s, %#o, uid=%u, gid=%u", devnode, mode, uid, gid);
-                        chmod(devnode, mode);
-                        chown(devnode, uid, gid);
+                        ;
+                        if((chmod(devnode, mode) !=0 ) || (chown(devnode, uid,gid) !=0)) {
+				                err = -errno;  
+                                log_error("FAILED to set permissions %s, %#o, uid=%u, gid=%u"
+								          ,devnode, mode, uid, gid);
+								goto out;
+						}
                 } else {
                         log_debug("preserve permissions %s, %#o, uid=%u, gid=%u", devnode, mode, uid, gid);
                 }

--- a/src/udev/udevadm-settle.c
+++ b/src/udev/udevadm-settle.c
@@ -201,7 +201,10 @@ static int adm_settle(struct udev *udev, int argc, char *argv[])
                         if (poll(pfd, 1, delay) > 0 && pfd[0].revents & POLLIN) {
                                 char buf[sizeof(struct inotify_event) + PATH_MAX];
 
-                                read(pfd[0].fd, buf, sizeof(buf));
+                                if(read(pfd[0].fd, buf, sizeof(buf)) < 0){
+								        log_error("failed to read /run/udev");
+										goto out;
+								}
                         }
                 } else {
                         sleep(1);

--- a/src/udev/udevd.c
+++ b/src/udev/udevd.c
@@ -1031,7 +1031,10 @@ int main(int argc, char *argv[])
         }
 
         /* set umask before creating any file/directory */
-        chdir("/");
+        if(chdir("/")!= 0) {
+                log_error("unable to change into directory '/'");
+                goto exit;
+        }
         umask(022);
 
         mkdir("/run/udev", 0755);


### PR DESCRIPTION
modified:   src/collect/collect.c
modified:   src/udev/udev-node.c
modified:   src/udev/udevadm-settle.c
modified:   src/udev/udevd.c
GCC warns that the return values are not being checked for some  stdlib calls.  This patch adds checking for these calls and returns error values in keeping with the surrounding code if they fail.
