### PR TITLE
src/ata_id/Makefile.am: Fixed compilation error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ AC_CHECK_FUNCS(
         [AC_MSG_ERROR([*** POSIX function not found])]
 )
 AC_SEARCH_LIBS([clock_gettime], [rt], [], [AC_MSG_ERROR([*** POSIX librt not found])])
-AC_SEARCH_LIBS([sqrt], [m], [], [AC_MSG_ERROR([*** POSIX libm not found])])
+LT_LIB_M
 
 # ------------------------------------------------------------------------------
 

--- a/src/accelerometer/Makefile.am
+++ b/src/accelerometer/Makefile.am
@@ -13,4 +13,4 @@ accelerometer_SOURCES = \
 accelerometer_LDADD = \
 	$(top_builddir)/src/libudev/libudev-private.la \
 	$(top_builddir)/src/udev/libudev-core.la \
-	-lm
+	$(LIBM)

--- a/src/ata_id/Makefile.am
+++ b/src/ata_id/Makefile.am
@@ -2,6 +2,7 @@ ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 AM_CPPFLAGS = \
 	-I $(top_srcdir)/src/shared \
+	-I $(top_srcdir)/src/udev \
 	-I $(top_srcdir)/src/libudev
 
 udevlibexec_PROGRAMS = \

--- a/src/shared/log.c
+++ b/src/shared/log.c
@@ -188,12 +188,6 @@ int log_open(void) {
             getpid() == 1 ||
             isatty(STDERR_FILENO) <= 0) {
 
-                if (log_target == LOG_TARGET_AUTO)
-                    if (r >= 0) {
-                        log_close_syslog();
-                        log_close_console();
-                        return r;
-                     }
                 if (log_target == LOG_TARGET_SYSLOG_OR_KMSG ||
                     log_target == LOG_TARGET_SYSLOG) {
                         r = log_open_syslog();


### PR DESCRIPTION
It is necessary to include src/udev to the include path, because
ata_id.c includes src/shared/udev-util.h which itself includes
src/udev/udev.h

Fixes issue #102 