### PR TITLE
Build files: remove extraneous dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ AC_CHECK_FUNCS(
         [AC_MSG_ERROR([*** POSIX function not found])]
 )
 AC_SEARCH_LIBS([clock_gettime], [rt], [], [AC_MSG_ERROR([*** POSIX librt not found])])
-AC_SEARCH_LIBS([sqrt], [m], [], [AC_MSG_ERROR([*** POSIX libm not found])])
+LT_LIB_M
 
 # ------------------------------------------------------------------------------
 

--- a/src/accelerometer/Makefile.am
+++ b/src/accelerometer/Makefile.am
@@ -13,4 +13,4 @@ accelerometer_SOURCES = \
 accelerometer_LDADD = \
 	$(top_builddir)/src/libudev/libudev-private.la \
 	$(top_builddir)/src/udev/libudev-core.la \
-	-lm
+	$(LIBM)


### PR DESCRIPTION
* configure.ac: use LT_LIBM to check for the maths library
* src/accelerometer/Makefile.am: use $(LIBM) instead of -lm in the link
flags

This causes all executables (except accelerometer) and libraries to be
linked without libm, which they do not need.