### PR TITLE
src/ata_id/Makefile.am: Fixed compilation error

### DIFF
--- a/src/ata_id/Makefile.am
+++ b/src/ata_id/Makefile.am
@@ -2,6 +2,7 @@ ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 AM_CPPFLAGS = \
 	-I $(top_srcdir)/src/shared \
+	-I $(top_srcdir)/src/udev \
 	-I $(top_srcdir)/src/libudev
 
 udevlibexec_PROGRAMS = \


### PR DESCRIPTION
It is necessary to include src/udev to the include path, because
ata_id.c includes src/shared/udev-util.h which itself includes
src/udev/udev.h

Fixes issue #102. Exact same pull request as #103, except not using the master branch. Sorry about that.