### PR TITLE
Musl fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,8 +66,9 @@ AC_C_INLINE
 AC_TYPE_MODE_T
 AC_TYPE_PID_T
 AC_CHECK_MEMBERS([struct stat.st_rdev])
-AC_CHECK_DECLS([getrandom, gettid, name_to_handle_at, accept4, mkostemp], [], [], [[#include <sys/types.h>
+AC_CHECK_DECLS([getrandom, gettid, name_to_handle_at, accept4, mkostemp, strndupa], [], [], [[#include <sys/types.h>
 #include <unistd.h>
+#include <string.h>
 #include <sys/mount.h>
 #include <fcntl.h>
 #include <sys/socket.h>

--- a/configure.ac
+++ b/configure.ac
@@ -223,6 +223,9 @@ else
 fi
 AC_SUBST(sushell)
 
+# selinux-util.c uses struct mallinfo which is not available for all C libraries (musl).
+AC_CHECK_FUNCS([mallinfo])
+
 # ------------------------------------------------------------------------------
 
 AC_CHECK_DECL([unshare],

--- a/src/shared/missing.h
+++ b/src/shared/missing.h
@@ -158,3 +158,14 @@ static inline int name_to_handle_at(int fd, const char *name, struct file_handle
 #ifndef AT_EMPTY_PATH
 #define AT_EMPTY_PATH 0x1000
 #endif
+
+#if !HAVE_DECL_STRNDUPA
+#define strndupa(s, n) \
+  ({ \
+    const char *__old = (s); \
+    size_t __len = strnlen(__old, (n)); \
+    char *__new = (char *)alloca(__len + 1); \
+    __new[__len] = '\0'; \
+    (char *)memcpy(__new, __old, __len); \
+  })
+#endif

--- a/src/shared/selinux-util.c
+++ b/src/shared/selinux-util.c
@@ -67,7 +67,10 @@ int mac_selinux_init(const char *prefix) {
 
 #ifdef HAVE_SELINUX
         usec_t before_timestamp, after_timestamp;
+
+#ifdef HAVE_MALLINFO
         struct mallinfo before_mallinfo, after_mallinfo;
+#endif
 
         if (!mac_selinux_use())
                 return 0;
@@ -75,7 +78,10 @@ int mac_selinux_init(const char *prefix) {
         if (label_hnd)
                 return 0;
 
+#ifdef HAVE_MALLINFO
         before_mallinfo = mallinfo();
+#endif
+
         before_timestamp = now(CLOCK_MONOTONIC);
 
         if (prefix) {
@@ -92,9 +98,14 @@ int mac_selinux_init(const char *prefix) {
                 r = security_getenforce() == 1 ? -errno : 0;
         } else  {
                 char timespan[FORMAT_TIMESPAN_MAX];
+
+#ifdef HAVE_MALLINFO
                 int l;
+#endif
 
                 after_timestamp = now(CLOCK_MONOTONIC);
+
+#ifdef HAVE_MALLINFO
                 after_mallinfo = mallinfo();
 
                 l = after_mallinfo.uordblks > before_mallinfo.uordblks ? after_mallinfo.uordblks - before_mallinfo.uordblks : 0;
@@ -102,6 +113,10 @@ int mac_selinux_init(const char *prefix) {
                 log_debug("Successfully loaded SELinux database in %s, size on heap is %iK.",
                           format_timespan(timespan, sizeof(timespan), after_timestamp - before_timestamp, 0),
                           (l+1023)/1024);
+#else
+                log_debug("Successfully loaded SELinux database in %s",
+                          format_timespan(timespan, sizeof(timespan), after_timestamp - before_timestamp, 0));
+#endif
         }
 #endif
 

--- a/src/shared/selinux-util.c
+++ b/src/shared/selinux-util.c
@@ -31,6 +31,7 @@
 #include "strv.h"
 #include "path-util.h"
 #include "selinux-util.h"
+#include "missing.h"
 
 #ifdef HAVE_SELINUX
 DEFINE_TRIVIAL_CLEANUP_FUNC(security_context_t, freecon);


### PR DESCRIPTION
Hi,

Add a patch to disable mallinfo statistics with musl toolchains
which doesn't have struct mallinfo.

Fixes:
selinux-util.c: In function ‘mac_selinux_init’:
selinux-util.c:70:25: error: storage size of ‘before_mallinfo’ isn’t known
         struct mallinfo before_mallinfo, after_mallinfo;

Add a second patch for strndupa() which is a GNU extension.

Fixes:
./.libs/libudev-core.a(selinux-util.o): In function `mac_selinux_bind':
selinux-util.c:(.text+0xd94): undefined reference to `strndupa'
collect2: error: ld returned 1 exit status

Best regards,
Romain Naour