### PR TITLE
configure.ac: Move udevhwdbdir and udevhwdbin to udevlibexecdir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -177,6 +177,7 @@ AC_SUBST([udevhwdbbin],[${udevconfdir}/hwdb.bin])
 # udevlibexecdir paths
 AC_SUBST([udevkeymapdir],[${udevlibexecdir}/keymaps])
 AC_SUBST([udevkeymapforceredir],[${udevkeymapdir}/force-release])
+AC_SUBST([udevlibexechwdbdir],[${udevlibexecdir}/hwdb.d])
 AC_SUBST([udevrulesdir],[${udevlibexecdir}/rules.d])
 
 # pkgconfigdir paths

--- a/hwdb/Makefile.am
+++ b/hwdb/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
-dist_udevhwdb_DATA = \
+dist_udevlibexechwdb_DATA = \
 	20-OUI.hwdb \
 	20-acpi-vendor.hwdb \
 	20-bluetooth-vendor-product.hwdb \


### PR DESCRIPTION
There doesn't seem to be much reason for sysadmins to edit these, so
they'd probably be just fine out of (usual) sight in $udevlibexecdir

However, there may very well be some rationale that I'm missing here, so this pull request is as much of an RFC as it is a pull request... :-)