### PR TITLE
Install hwdb.d/ to $udevlibexecdir by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -177,6 +177,7 @@ AC_SUBST([udevhwdbbin],[${udevconfdir}/hwdb.bin])
 # udevlibexecdir paths
 AC_SUBST([udevkeymapdir],[${udevlibexecdir}/keymaps])
 AC_SUBST([udevkeymapforceredir],[${udevkeymapdir}/force-release])
+AC_SUBST([udevlibexechwdbdir],[${udevlibexecdir}/hwdb.d])
 AC_SUBST([udevrulesdir],[${udevlibexecdir}/rules.d])
 
 # pkgconfigdir paths

--- a/hwdb/Makefile.am
+++ b/hwdb/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
-dist_udevhwdb_DATA = \
+dist_udevlibexechwdb_DATA = \
 	20-OUI.hwdb \
 	20-acpi-vendor.hwdb \
 	20-bluetooth-vendor-product.hwdb \


### PR DESCRIPTION
This installs the hwdb.d "source" files to $udevlibexecdir/hwdb.d/ by default while leaving the hwdb.bin location alone.
Looking at src/udev/udevadm-hwdb.c, udevlibexecdir is hardcoded, while udevhwdbdir comes from autotools. It appears that the intent is to have the packaged files in udevlibexecdir with sysadmin overrides in udevhwdbdir, and that is what I experienced in systemd-udev v219 (though things may have changed since then).
