### PR TITLE
src/shared/missing.h: fix getrandom system call number on ARM64

### DIFF
--- a/src/shared/missing.h
+++ b/src/shared/missing.h
@@ -47,8 +47,10 @@
 #    define __NR_getrandom 318
 #  elif defined(__i386__)
 #    define __NR_getrandom 355
-#  elif defined(__arm__) || defined(__aarch64__)
+#  elif defined(__arm__)
 #    define __NR_getrandom 384
+#  elif defined(__aarch64__)
+#    define __NR_getrandom 278
 #  elif defined(__ia64__)
 #    define __NR_getrandom 1339
 #  elif defined(__m68k__)


### PR DESCRIPTION
The getrandom() system call number is indeed 384 on ARM, but it is not
the same on ARM64. ARM64 uses the asm-generic headers, including for
system call numbers, so the getrandom() system call number on ARM64 is
278. This fixes runtime issues of eudev on ARM64, such as:

Populating /dev using udev: [    6.186817] udevd[1204]: starting version 3.1.5
[    6.191662] udevd[1204]: syscall 384
[    6.195217] Code: aa0503e4 aa0603e5 aa0703e6 d4000001 (b13ffc1f)
[    6.201291] CPU: 4 PID: 1204 Comm: udevd Not tainted 4.7.0+ #1
[    6.207079] Hardware name: ARM Juno development board (r2) (DT)
[    6.212954] task: ffff800976421900 task.stack: ffff800975610000
[    6.218825] PC is at 0xffff97f12234
[    6.222281] LR is at 0x41b15c
[    6.225214] pc : [<0000ffff97f12234>] lr : [<000000000041b15c>] pstate: 80000000
[    6.232544] sp : 0000ffffcf9b3870
[    6.235828] x29: 0000ffffcf9b3870 x28: 0000000000428218
[    6.241110] x27: 0000000000000000 x26: 000000000042a7e3
[    6.246395] x25: 0000ffffcf9b39c8 x24: 0000000000428000
[    6.251670] x23: 0000000000449000 x22: 0000000000449678
[    6.256946] x21: 0000000000000010 x20: 0000000000449000
[    6.262233] x19: 0000000000449678 x18: 0000000000000000
[    6.267507] x17: 0000ffff97f12210 x16: 0000000000449440
[    6.272779] x15: 0000ffff97e4f730 x14: 0000ffff98050cb8
[    6.278060] x13: 000000000000033c x12: 00000000000004b4
[    6.283331] x11: 0000000000000000 x10: 0101010101010101
[    6.288604] x9 : 0000000000001010 x8 : 0000000000000180
[    6.293882] x7 : ffffffffffffffff x6 : ffffffffffffffff
[    6.299154] x5 : 00000000271e36c0 x4 : 0007061c00190d07
[    6.304426] x3 : 00000000271e36d0 x2 : 0000000000000001
[    6.309705] x1 : 0000000000000010 x0 : 0000000000449678
[    6.314976]
[    6.398734] sky2 0000:08:00.0 enp8s0: renamed from eth0

Reported-by: Kevin Hilman <khilman@baylibre.com>
Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>