### PR TITLE
configure.ac: add option to disable mtd_probe

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -284,6 +284,14 @@ fi
 AM_CONDITIONAL([ENABLE_RULE_GENERATOR], [test "x$enable_rule_generator" = xyes])
 
 # ------------------------------------------------------------------------------
+# mtd_probe - autoloads FTL module for mtd devices
+# ------------------------------------------------------------------------------
+AC_ARG_ENABLE([mtd_probe],
+	AS_HELP_STRING([--disable-mtd_probe], [disable MTD support]),
+	[], [enable_mtd_probe=yes])
+AM_CONDITIONAL([ENABLE_MTD_PROBE], [test "x$enable_mtd_probe" = xyes])
+
+# ------------------------------------------------------------------------------
 
 AC_CONFIG_FILES([Makefile
                  hwdb/Makefile

--- a/rules/Makefile.am
+++ b/rules/Makefile.am
@@ -16,7 +16,6 @@ dist_udevrules_DATA = \
 	70-mouse.rules \
 	70-touchpad.rules \
 	75-net-description.rules \
-	75-probe_mtd.rules \
 	78-sound-card.rules
 
 if !ENABLE_RULE_GENERATOR
@@ -32,6 +31,11 @@ endif
 if HAVE_KMOD
 dist_udevrules_DATA += \
 	80-drivers.rules
+endif
+
+if ENABLE_MTD_PROBE
+dist_udevrules_DATA += \
+	75-probe_mtd.rules
 endif
 
 install-data-local:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,6 +10,10 @@ SUBDIRS += \
 	ata_id \
 	cdrom_id \
 	collect \
-	mtd_probe \
 	scsi_id \
 	v4l_id
+
+if ENABLE_MTD_PROBE
+SUBDIRS += \
+	mtd_probe
+endif


### PR DESCRIPTION
FTL is not necessarily present on all kernels so it's useful to
have an option to disable this.

Signed-off-by: Ioan-Adrian Ratiu <adrian.ratiu@ni.com>