### PR TITLE
udev-builtin-input_id.c: add missing kernel header defines.

### DIFF
--- a/src/shared/missing.h
+++ b/src/shared/missing.h
@@ -171,3 +171,11 @@ static inline int name_to_handle_at(int fd, const char *name, struct file_handle
     (char *)memcpy(__new, __old, __len); \
   })
 #endif
+
+#ifndef BTN_TRIGGER_HAPPY
+#define BTN_TRIGGER_HAPPY 0x2c0
+#endif
+
+#ifndef INPUT_PROP_MAX
+#define INPUT_PROP_MAX 0x1f
+#endif

--- a/src/udev/udev-builtin-input_id.c
+++ b/src/udev/udev-builtin-input_id.c
@@ -32,6 +32,7 @@
 
 #include "udev.h"
 #include "util.h"
+#include "missing.h"
 
 /* we must use this kernel-compatible implementation */
 #define BITS_PER_LONG (sizeof(unsigned long) * 8)


### PR DESCRIPTION
Add missing defines so eudev builds for older kernels such as 2.6

Signed-off-by: Gustavo Sverzut Barbieri <barbieri@profusion.mobi>