### PR TITLE
configure.ac: add option to disable building programs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,13 @@
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 SUBDIRS = \
-	src \
+	src
+
+if ENABLE_PROGRAMS
+SUBDIRS += \
 	rules \
 	test
+endif
 
 if ENABLE_MANPAGES
 SUBDIRS += \

--- a/configure.ac
+++ b/configure.ac
@@ -197,6 +197,12 @@ GOBJECT_INTROSPECTION_CHECK([1.31.1])
 AM_CONDITIONAL([HAVE_INTROSPECTION], [test "$enable_introspection" = "yes"])
 
 # ------------------------------------------------------------------------------
+AC_ARG_ENABLE([programs],
+        AS_HELP_STRING([--disable-programs], [disable programs (udevd, udevadm and helpers)]),
+        [], [enable_programs="yes"])
+AM_CONDITIONAL([ENABLE_PROGRAMS], [test "x$enable_programs" = "xyes"])
+
+# ------------------------------------------------------------------------------
 have_blkid=no
 AC_ARG_ENABLE(blkid, AS_HELP_STRING([--disable-blkid], [Disable optional blkid support]))
 if test "x$enable_blkid" != "xno"; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,11 +2,13 @@ ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = \
 	shared \
-	libudev \
+	libudev
+
+PROGRAMS_SUBDIRS = \
 	udev
 
 # Helper programs
-SUBDIRS += \
+PROGRAMS_SUBDIRS += \
 	ata_id \
 	cdrom_id \
 	collect \
@@ -14,6 +16,10 @@ SUBDIRS += \
 	v4l_id
 
 if ENABLE_MTD_PROBE
-SUBDIRS += \
+PROGRAMS_SUBDIRS += \
 	mtd_probe
+endif
+
+if ENABLE_PROGRAMS
+SUBDIRS += $(PROGRAMS_SUBDIRS)
 endif


### PR DESCRIPTION
In some cases (e.g. trimmed-down chroot or containers), libudev is the
only thing needed, with udevd and assorted programs totally useless
(e.g. because /dev is bind-mounted from the real one and managed
out-side the chroot/container).

Add an option to ./configure to enable/disable building the programs;
this option defaults to "enable", so that it is backward compatible with
existing build procedure, and because it by default makes sense to have
udevd et al.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>