### PR TITLE
man: add short options to udevd.xml and update pregenerated udev manpage

### DIFF
--- a/man/udev.7
+++ b/man/udev.7
@@ -1,8 +1,8 @@
 '\" t
 .\"     Title: udev
 .\"    Author: Greg Kroah-Hartmann <greg@kroah.com>
-.\" Generator: DocBook XSL Stylesheets v1.79.0 <http://docbook.sf.net/>
-.\"      Date: 12/11/2016
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 03/08/2018
 .\"    Manual: udev
 .\"    Source: udev
 .\"  Language: English
@@ -538,35 +538,6 @@ The
 $
 character itself\&.
 .RE
-.SH "HARDWARE DATABASE FILES"
-.PP
-The hwdb files are read from the files located in the system hwdb directory
-/lib/udev/hwdb\&.d, the volatile runtime directory
-/run/udev/hwdb\&.d
-and the local administration directory
-/etc/udev/hwdb\&.d\&. All hwdb files are collectively sorted and processed in lexical order, regardless of the directories in which they live\&. However, files with identical filenames replace each other\&. Files in
-/etc
-have the highest priority, files in
-/run
-take precedence over files with the same name in
-/lib\&. This can be used to override an hwdb file with a local file if needed; a symlink in
-/etc
-with the same name as a hwdb file in
-/lib, pointing to
-/dev/null, disables the hwdb file entirely\&. hwdb files must have the extension
-\&.hwdb; other extensions are ignored\&.
-.PP
-The hwdb file contains data records consisting of matches and associated key\-value pairs\&. Every record in the hwdb starts with one or more match string, specifying a shell glob to compare the database lookup string against\&. Multiple match lines are specified in additional consecutive lines\&. Every match line is compared indivdually, they are combined by OR\&. Every match line must start at the first character of the line\&.
-.PP
-The match lines are followed by one or more key\-value pair lines, which are recognized by a leading space character\&. The key name and value are separated by
-=\&. An empty line signifies the end of a record\&. Lines beginning with
-#
-are ignored\&.
-.PP
-The content of all hwdb files is read by
-\fBudevadm\fR(8)
-and compiled to a binary database located at
-/etc/udev/hwdb\&.bin\&. During runtime only the binary database is used\&.
 .SH "HARDWARE DATABASE FILES"
 .PP
 The hwdb files are read from the files located in the system hwdb directory

--- a/man/udevd.8
+++ b/man/udevd.8
@@ -1,8 +1,8 @@
 '\" t
 .\"     Title: udevd
 .\"    Author: Kay Sievers <kay@vrfy.org>
-.\" Generator: DocBook XSL Stylesheets v1.79.0 <http://docbook.sf.net/>
-.\"      Date: 12/11/2016
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 03/08/2018
 .\"    Manual: udevd
 .\"    Source: eudev
 .\"  Language: English
@@ -45,35 +45,35 @@ The behavior of the daemon can be configured using
 \fBudevadm control\fR\&.
 .SH "OPTIONS"
 .PP
-\fB\-d\fR,\fB\-\-daemon\fR
-.RS 5
+\fB\-d\fR, \fB\-\-daemon\fR
+.RS 4
 Detach and run in the background\&.
 .RE
 .PP
 \fB\-D\fR, \fB\-\-debug\fR
-.RS 5
+.RS 4
 Print debug messages to standard error\&.
 .RE
 .PP
 \fB\-c\fR, \fB\-\-children\-max=\fR
-.RS 5
+.RS 4
 Limit the number of events executed in parallel\&.
 .RE
 .PP
 \fB\-e\fR, \fB\-\-exec\-delay=\fR
-.RS 5
+.RS 4
 Delay the execution of
 \fIRUN\fR
 instructions by the given number of seconds\&. This option might be useful when debugging system crashes during coldplug caused by loading non\-working kernel modules\&.
 .RE
 .PP
 \fB\-t\fR, \fB\-\-event\-timeout=\fR
-.RS 5
+.RS 4
 Set the number of seconds to wait for events to finish\&. After this time the event will be terminated\&. The default is 30 seconds\&.
 .RE
 .PP
 \fB\-N\fR, \fB\-\-resolve\-names=\fR
-.RS 5
+.RS 4
 Specify when udevd should resolve names of users and groups\&. When set to
 \fBearly\fR
 (the default), names will be resolved when the rules are parsed\&. When set to
@@ -82,7 +82,7 @@ Specify when udevd should resolve names of users and groups\&. When set to
 .RE
 .PP
 \fB\-h\fR, \fB\-\-help\fR
-.RS 5
+.RS 4
 .RE
 .SH "KERNEL COMMAND LINE"
 .PP

--- a/man/udevd.xml
+++ b/man/udevd.xml
@@ -62,28 +62,28 @@
   <refsect1><title>Options</title>
     <variablelist>
       <varlistentry>
-        <term><option>--daemon</option></term>
+        <term><option>-d</option>, <option>--daemon</option></term>
         <listitem>
           <para>Detach and run in the background.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
-        <term><option>--debug</option></term>
+        <term><option>-D</option>, <option>--debug</option></term>
         <listitem>
           <para>Print debug messages to standard error.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
-        <term><option>--children-max=</option></term>
+        <term><option>-c</option>, <option>--children-max=</option></term>
         <listitem>
           <para>Limit the number of events executed in parallel.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
-        <term><option>--exec-delay=</option></term>
+        <term><option>-e</option>, <option>--exec-delay=</option></term>
         <listitem>
           <para>Delay the execution of <varname>RUN</varname>
           instructions by the given number of seconds. This option
@@ -94,7 +94,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>--event-timeout=</option></term>
+        <term><option>-t</option>, <option>--event-timeout=</option></term>
         <listitem>
           <para>Set the number of seconds to wait for events to finish. After
           this time the event will be terminated. The default is 30 seconds.</para>
@@ -102,7 +102,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>--resolve-names=</option></term>
+        <term><option>-N</option>, <option>--resolve-names=</option></term>
         <listitem>
           <para>Specify when udevd should resolve names of users and groups.
           When set to <option>early</option> (the default), names will be
@@ -114,7 +114,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>--help</option></term>
+        <term><option>-h</option>, <option>--help</option></term>
 
       </varlistentry>
     </variablelist>


### PR DESCRIPTION
Short options which were added to the udevd manpage in e3eb943, were not added to
the .xml file, and everytime manpages get regenerated the change gets
overwritten.

Also update pregenerated version of udev manpage.