### PR TITLE
udev/Makefile.am: change udev.pc to pkgconfiglib_DATA

### DIFF
--- a/src/udev/Makefile.am
+++ b/src/udev/Makefile.am
@@ -92,7 +92,7 @@ endif
 dist_udevconf_DATA = \
 	udev.conf
 
-sharepkgconfig_DATA = \
+pkgconfiglib_DATA = \
 	udev.pc
 
 EXTRA_DIST = \


### PR DESCRIPTION
udev.pc is library path related. It affects multilib. When both eudev
and lib32-eudev are installed, it causes file conflicts. So install
udev.pc to $(pkgconfiglibdir) to fix the issue.

Signed-off-by: Kai Kang <kai.kang@windriver.com>