### PR TITLE
missing.h: add KEY_ALS_TOGGLE

### DIFF
--- a/src/shared/missing.h
+++ b/src/shared/missing.h
@@ -179,3 +179,7 @@ static inline int name_to_handle_at(int fd, const char *name, struct file_handle
 #ifndef INPUT_PROP_MAX
 #define INPUT_PROP_MAX 0x1f
 #endif
+
+#ifndef KEY_ALS_TOGGLE
+#define KEY_ALS_TOGGLE 0x7a
+#endif


### PR DESCRIPTION
KEY_ALS_TOGGLE has been added in kernel 4.8 with
https://github.com/torvalds/linux/commit/9ee27487127461b5cf71670b708ed5b2b8da568c

So add it to missing.h to fix build with kernel older than 4.8

Fixes:
 - http://autobuild.buildroot.org/results/0c0aff02df91cdb869efa01e397f7ccc0d9f69af

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>