### PR TITLE
missing.h: add BTN_DPAD_UP

### DIFF
--- a/src/shared/missing.h
+++ b/src/shared/missing.h
@@ -183,3 +183,8 @@ static inline int name_to_handle_at(int fd, const char *name, struct file_handle
 #ifndef KEY_ALS_TOGGLE
 #define KEY_ALS_TOGGLE 0x7a
 #endif
+
+#ifndef BTN_DPAD_UP
+#define BTN_DPAD_UP 0x220
+#define BTN_DPAD_RIGHT 0x223
+#endif


### PR DESCRIPTION
As explained in issue 6267 of systemd [1], Linux < 3.11 does not
provide definitions for BTN_DPAD_{UP,RIGHT}, which were introduced in
[2].

This patch fixes this issue, reported by Buildroot autobuilders [3]

[1] https://github.com/systemd/systemd/pull/6267
[2] https://github.com/torvalds/linux/commit/9ee27487127461b5cf71670b708ed5b2b8da568c
[3] http://autobuild.buildroot.net/results/e9d94084be8ed3296ba63cffdb9d69ffcc3b7140/