### PR TITLE
Properly handle empty tag list

### DIFF
--- a/src/libudev/libudev-device.c
+++ b/src/libudev/libudev-device.c
@@ -1392,6 +1392,8 @@ _public_ struct udev_list_entry *udev_device_get_properties_list_entry(struct ud
                         udev_list_entry_foreach(list_entry, udev_device_get_tags_list_entry(udev_device))
                                 l = strpcpyl(&s, l, udev_list_entry_get_name(list_entry), ":", NULL);
                         udev_device_add_property_internal(udev_device, "TAGS", tags);
+                } else {
+                        udev_device_add_property_internal(udev_device, "TAGS", NULL);
                 }
         }
         return udev_list_get_entry(&udev_device->properties_list);


### PR DESCRIPTION
This PR attempts to fix a bug which makes it impossible to remove the last existing tag for a device.

Consider the `power-switch` tag.  elogind ships with a file called [`70-power-switch.rules`][1] which applies that tag to certain devices.  Try removing it e.g. for the ACPI Power Button device by creating an appropriately numbered rule file (e.g.  `/etc/udev/rules.d/75-remove-power-switch.rules`) with the following contents:

```
SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_KEY}=="1", TAG-="power-switch"
```

This will not remove the `power-switch` tag for the device:

```
$ udevadm test "/sys/$(udevadm info -q path /dev/input/event1)" 2>&1 | grep TAGS
TAGS=:power-switch
```

If you add any other tag to the tag list for the same device, e.g. by making the aforementioned rule file look like this:

```
SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_KEY}=="1", TAG-="power-switch"
SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_KEY}=="1", TAG+="foo"
```

the `power-switch` tag will be removed correctly:

```
$ udevadm test "/sys/$(udevadm info -q path /dev/input/event1)" 2>&1 | grep TAGS
TAGS=:foo:
```

The reason for this behavior is that `udev_device_get_properties_list_entry()` only updates the `TAGS` property if the tag list is non-empty.

I believe this is an upstream bug which was fixed in v220 as a side effect of commits [57fa1d094cd2c5ac68970526ad0a0754c548e75d][2] and [f4ac4d1a82e2c468761fffa333323841ad886221][3].  Since eudev did not adopt these changes, the bug remained unfixed.

I was not sure how to sum up all of the above in the commit log message, so please let me know if it should be adjusted.

Hope this helps!

[1]: https://github.com/elogind/elogind/blob/master/src/login/70-power-switch.rules
[2]: https://github.com/systemd/systemd/commit/57fa1d094cd2c5ac68970526ad0a0754c548e75d
[3]: https://github.com/systemd/systemd/commit/f4ac4d1a82e2c468761fffa333323841ad886221
