### PR TITLE
rules/64-btrfs.rules: Expand @bindir@ to the absolute directory name.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -305,7 +305,6 @@ AC_CONFIG_FILES([Makefile
                  rule_generator/Makefile
                  rule_generator/write_net_rules
                  rules/Makefile
-                 rules/64-btrfs.rules
                  src/Makefile
                  src/ata_id/Makefile
                  src/cdrom_id/Makefile

--- a/rules/Makefile.am
+++ b/rules/Makefile.am
@@ -43,5 +43,11 @@ dist_udevrules_DATA += \
 	75-probe_mtd.rules
 endif
 
+do_subst = $(SED) \
+	-e 's,[@]bindir[@],$(bindir),g'
+
+64-btrfs.rules: 64-btrfs.rules.in Makefile
+	$(do_subst) < $< > $@
+
 install-data-local:
 	$(MKDIR_P) $(DESTDIR)$(udevconfdir)/rules.d


### PR DESCRIPTION
This fixes #182 by ensuring @bindir@ is fully expanded at installation
time.  See "Installation Directory Variables" in the GNU Autoconf
manual, in particular the note about AC_CONFIG_FILES.

Link for the lazy: https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Installation-Directory-Variables.html#Installation-Directory-Variables

Before this patch, running `./configure && make -C rules` with no further arguments would create a 64-btrfs.rules with the literal string `{exec_prefix}/bin/udevadm`.  Now it gets properly substituted to e.g. `/usr/local/bin/udevadm`.