### PR TITLE
switch make usage to be POSIX compatible

### DIFF
--- a/rules/Makefile.am
+++ b/rules/Makefile.am
@@ -3,6 +3,9 @@ ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 EXTRA_DIST = \
 	64-btrfs.rules.in
 
+CLEANFILES = \
+	64-btrfs.rules
+
 dist_udevrules_DATA = \
 	50-udev-default.rules \
 	60-block.rules \
@@ -46,8 +49,8 @@ endif
 do_subst = $(SED) \
 	-e 's,[@]bindir[@],$(bindir),g'
 
-64-btrfs.rules: 64-btrfs.rules.in Makefile
-	$(do_subst) < $< > $@
+64-btrfs.rules: $(srcdir)/64-btrfs.rules.in Makefile
+	$(do_subst) $(srcdir)/64-btrfs.rules.in > 64-btrfs.rules
 
 install-data-local:
 	$(MKDIR_P) $(DESTDIR)$(udevconfdir)/rules.d

--- a/src/libudev/Makefile.am
+++ b/src/libudev/Makefile.am
@@ -4,16 +4,6 @@ LIBUDEV_CURRENT=7
 LIBUDEV_REVISION=3
 LIBUDEV_AGE=6
 
-define move-to-rootlibdir
-	if test "$(libdir)" != "$(rootlibdir)"; then \
-		$(MKDIR_P) $(DESTDIR)$(rootlibdir) && \
-		so_img_name=$$(readlink $(DESTDIR)$(libdir)/$$libname) && \
-		so_img_rel_target_prefix=$$(echo $(libdir) | sed 's,\(^/\|\)[^/][^/]*,..,g') && \
-		$(LN_S) -f $$so_img_rel_target_prefix$(rootlibdir)/$$so_img_name $(DESTDIR)$(libdir)/$$libname && \
-		mv $(DESTDIR)$(libdir)/$$libname.* $(DESTDIR)$(rootlibdir); \
-	fi
-endef
-
 AM_CPPFLAGS = \
 	-include $(top_builddir)/config.h \
 	-DUDEV_ROOT_RUN=\"$(rootrundir)\" \
@@ -80,7 +70,14 @@ CLEANFILES = \
 	libudev.pc
 
 install-exec-hook:
-	libname=libudev.so && $(move-to-rootlibdir)
+	libname=libudev.so; if test "$(libdir)" != "$(rootlibdir)"; then \
+		$(MKDIR_P) $(DESTDIR)$(rootlibdir) && \
+		so_img_name=$$(readlink $(DESTDIR)$(libdir)/$$libname) && \
+		so_img_rel_target_prefix=$$(echo $(libdir) | sed 's,\(^/\)\?[^/]\+,..,g') && \
+		$(LN_S) -f $$so_img_rel_target_prefix$(rootlibdir)/$$so_img_name $(DESTDIR)$(libdir)/$$libname && \
+		mv $(DESTDIR)$(libdir)/$$libname.* $(DESTDIR)$(rootlibdir); \
+	fi
+
 
 uninstall-hook:
 	rm -f $(DESTDIR)$(rootlibdir)/libudev.so*

--- a/src/udev/Makefile.am
+++ b/src/udev/Makefile.am
@@ -113,17 +113,17 @@ nodist_libudev_core_la_SOURCES = \
 	keyboard-keys-to-name.h
 
 keyboard-keys.txt: Makefile
-	$(AM_V_at)$(MKDIR_P) $(dir $@)
+	$(AM_V_at)f="$@"; case $$f in */*) $(MKDIR_P) "$${f%/*}"; esac
 	$(AM_V_GEN)$(CPP) $(CFLAGS) $(AM_CPPFLAGS) $(CPPFLAGS) -dM -include linux/input.h - < /dev/null | $(AWK) '/^#define[ \t]+KEY_[^ ]+[ \t]+[0-9]/ { if ($$2 != "KEY_MAX") { print $$2 } }' | sed 's/^KEY_COFFEE$$/KEY_SCREENLOCK/' > $@
 
 keyboard-keys-from-name.gperf: keyboard-keys.txt Makefile
-	$(AM_V_GEN)$(AWK) 'BEGIN{ print "struct key { const char* name; unsigned short id; };"; print "%null-strings"; print "%%";} { print tolower(substr($$1 ,5)) ", " $$1 }' < $< > $@
+	$(AM_V_GEN)$(AWK) 'BEGIN{ print "struct key { const char* name; unsigned short id; };"; print "%null-strings"; print "%%";} { print tolower(substr($$1 ,5)) ", " $$1 }' keyboard-keys.txt > $@
 
 keyboard-keys-from-name.h: keyboard-keys-from-name.gperf Makefile
-	$(AM_V_GPERF)$(GPERF) -L ANSI-C -t -N keyboard_lookup_key -H hash_key_name -p -C < $< > $@
+	$(AM_V_GPERF)$(GPERF) -L ANSI-C -t -N keyboard_lookup_key -H hash_key_name -p -C < keyboard-keys-from-name.gperf > $@
 
 keyboard-keys-to-name.h: keyboard-keys.txt Makefile
-	$(AM_V_GEN)$(AWK) 'BEGIN{ print "const char* const key_names[KEY_CNT] = { "} { print "[" $$1 "] = \"" $$1 "\"," } END{print "};"}' < $< > $@
+	$(AM_V_GEN)$(AWK) 'BEGIN{ print "const char* const key_names[KEY_CNT] = { "} { print "[" $$1 "] = \"" $$1 "\"," } END{print "};"}' keyboard-keys.txt > $@
 
 
 BUILT_SOURCES = \
@@ -136,9 +136,8 @@ CLEANFILES += \
 
 # install udevadm symlink in sbindir
 install-exec-hook:
-	if test "$(bindir)" != "$(sbindir)"; then \
-		$(LN_S) -n -f $(bindir)/udevadm $(DESTDIR)$(sbindir)/udevadm; \
-	fi
+	test "$(bindir)" = "$(sbindir)" || \
+		$(LN_S) -n -f $(bindir)/udevadm $(DESTDIR)$(sbindir)/udevadm
 
 uninstall-hook:
 	rm -Rf $(DESTDIR)$(sbindir)/udevadm

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -50,7 +50,7 @@ check_DATA = \
 	test/sys
 
 test/sys:
-	$(AM_V_at)$(MKDIR_P) $(dir $@)
+	$(AM_V_at)f="$@"; $(MKDIR_P) "$${f%/*}"
 	$(AM_V_GEN)tar -C $(top_builddir)/test/test -xJf $(top_srcdir)/test/sys.tar.xz
 
 test-sys-distclean:


### PR DESCRIPTION
This allows other make implementations, such as bmake, to use autotools' generated Makefiles.