### PR TITLE
configure: test -a|o is not POSIX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -208,7 +208,7 @@ AC_ARG_ENABLE(blkid, AS_HELP_STRING([--disable-blkid], [Disable optional blkid s
 if test "x$enable_blkid" != "xno"; then
         PKG_CHECK_MODULES([BLKID], [blkid >= 2.20],
                 [AC_DEFINE(HAVE_BLKID, 1, [Define if blkid is available]) have_blkid=yes], have_blkid=no)
-        if test "x$have_blkid" = xno -a "x$enable_blkid" = xyes; then
+        if test "x$have_blkid" = xno && test "x$enable_blkid" = xyes; then
                 AC_MSG_ERROR([*** blkid support requested but not found])
         fi
 fi
@@ -220,7 +220,7 @@ AC_ARG_ENABLE(selinux, AS_HELP_STRING([--disable-selinux], [Disable optional SEL
 if test "x$enable_selinux" != "xno"; then
         PKG_CHECK_MODULES([SELINUX], [libselinux >= 2.1.9],
                 [AC_DEFINE(HAVE_SELINUX, 1, [Define if SELinux is available]) have_selinux=yes], have_selinux=no)
-        if test "x$have_selinux" = xno -a "x$enable_selinux" = xyes; then
+        if test "x$have_selinux" = xno && test "x$enable_selinux" = xyes; then
                 AC_MSG_ERROR([*** SELinux support requested but libraries not found])
         fi
 fi
@@ -265,7 +265,7 @@ if test "x$enable_kmod" != "xno"; then
                         [AC_DEFINE(HAVE_KMOD, 1, [Define if kmod is available])],
                         AC_MSG_ERROR([*** kmod version >= 15 not found]))
         fi
-        if test "x$have_kmod" = xno -a "x$enable_kmod" = xyes; then
+        if test "x$have_kmod" = xno && test "x$enable_kmod" = xyes; then
                 AC_MSG_ERROR([*** kmod support requested, but libraries not found])
         fi
 fi


### PR DESCRIPTION
I faced `test: too many arguments` when building Linux-PAM using [sbase](https://core.suckless.org/sbase/).
This is due to a non-POSIX syntax `test ... -a ...` and `test … -o …`.

> The XSI extensions specifying the -a and -o binary primaries and the '(' and ')' operators have been marked obsolescent.

https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html

Related, https://github.com/linux-pam/linux-pam/pull/311 and https://github.com/karelzak/util-linux/pull/1216