### PR TITLE
Revert bad 78-sound-card.rules update causing path_id skip

### DIFF
--- a/rules/78-sound-card.rules
+++ b/rules/78-sound-card.rules
@@ -50,11 +50,6 @@ SUBSYSTEMS=="firewire", GOTO="skip_pci"
 SUBSYSTEMS=="pci", ENV{ID_BUS}="pci", ENV{ID_VENDOR_ID}="$attr{vendor}", ENV{ID_MODEL_ID}="$attr{device}"
 SUBSYSTEMS=="pci", GOTO="skip_pci"
 
-# If we reach here, the device nor any of its parents are USB/PCI/firewire bus devices.
-# If we now find a parent that is a platform device, assume that we're working with
-# an internal sound card.
-SUBSYSTEMS=="platform", ENV{SOUND_FORM_FACTOR}="internal", GOTO="sound_end"
-
 LABEL="skip_pci"
 
 # Define ID_ID if ID_BUS and ID_SERIAL are set. This will work for both


### PR DESCRIPTION
The following device properly got assigned ID_PATH with eudev 3.2.1,
but does not get it any more with recent versions:

P: /devices/platform/rt5651-sound/sound/card0
E: DEVPATH=/devices/platform/rt5651-sound/sound/card0
E: SOUND_FORM_FACTOR=internal
E: SOUND_INITIALIZED=1
E: SUBSYSTEM=sound
E: USEC_INITIALIZED=507638688065

This results in pulseaudio giving a non-stable card name by using a
device number.

I tracked the problem to commit
47367bc4df6f05a49cf4b5b0209153d77a9ade83, which changed (without
explaining why it does so) the rules for "internal" sound cards,
notably preventing `IMPORT{builtin}="path_id"` from being reached.

Signed-off-by: Yann Dirson <yann@blade-group.com>