### PR TITLE
Allow empty properties

### DIFF
--- a/src/udev/udevadm-hwdb.c
+++ b/src/udev/udevadm-hwdb.c
@@ -441,9 +441,8 @@ static int insert_data(struct trie *trie, struct udev_list *match_list,
         while (isblank(line[0]) && isblank(line[1]))
                 line++;
 
-        if (isempty(line + 1) || isempty(value)) {
-                log_error("Warning, empty %s in \"%s=%s\", ignoring",
-                          isempty(line + 1) ? "key" : "value",
+        if (isempty(line + 1)) {
+                log_error("Warning, empty key in \"%s=%s\", ignoring",
                           line, value);
                 return -EINVAL;
         }


### PR DESCRIPTION
I updated sys-apps/hwids to v20201207 yesterday for genkernel and noticed the following non-fatal error message during initramfs generation when `hwdb --update` is called:

> Error, empty key or value ' XKB_FIXED_VARIANT' in '/var/tmp/genkernel/gk_ROYm6weK/initramfs-eudev-temp/usr/lib/udev/hwdb.d/60-keyboard.hwdb'

I was able to track this down to the following change: https://github.com/gentoo/hwids/commit/f30071bbebc0685c645783024cae0f9f213a1458#diff-7b9ba9c30888b1b5b1fa008f185e4efaff34eaff2c13f35c38b2ae0416cd891eR1840

However, this seems to be valid now. Systemd applied the following change few months ago, https://github.com/systemd/systemd/commit/afe87974dd57741f74dd87165b251886f24c859f.

This PR will backport the change and also update `import_file()` and `insert_data()` functions with changes from https://github.com/systemd/systemd/commit/6a34639e76b8b59233a97533b13836d5a44e8d4a.