### PR TITLE
Makefile: flag -n of ln is not POSIX

### DIFF
--- a/src/udev/Makefile.am
+++ b/src/udev/Makefile.am
@@ -137,7 +137,7 @@ CLEANFILES += \
 # install udevadm symlink in sbindir
 install-exec-hook:
 	test "$(bindir)" = "$(sbindir)" || \
-		$(LN_S) -n -f $(bindir)/udevadm $(DESTDIR)$(sbindir)/udevadm
+		$(LN_S) -f $(bindir)/udevadm $(DESTDIR)$(sbindir)/udevadm
 
 uninstall-hook:
 	rm -Rf $(DESTDIR)$(sbindir)/udevadm


### PR DESCRIPTION
As you can see [here](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ln.html), `ln`’s flag `-n` does not exist. When I compile eudev in a distro using [sbase](https://core.suckless.org/sbase/) instead of GNU coreutils, I get:
```
test "/tmp/43e656512ab0043ae84a87f2290f168f913ff2ac-eudev/bin" = "/tmp/43e656512ab0043ae84a87f2290f168f913ff2ac-eudev/sbin" || \
        ln -s -n -f /tmp/43e656512ab0043ae84a87f2290f168f913ff2ac-eudev/bin/udevadm /tmp/43e656512ab0043ae84a87f2290f168f913ff2ac-eudev/sbin/udevadm
usage: ln [-f] [-L | -P | -s] target [name]
       ln [-f] [-L | -P | -s] target ... dir
gmake[5]: *** [Makefile:1207: install-exec-hook] Error 1
```
You can see this PR as a follow-up of https://github.com/gentoo/eudev/pull/189.