### PR TITLE
udevd: add support for S6/dinit-compatible readiness notification

### DIFF
--- a/man/udevd.8
+++ b/man/udevd.8
@@ -25,7 +25,7 @@ udevd \- Device event managing daemon
 .PP
 udevd
 .HP \w'\fB/sbin/udevd\fR\ 'u
-\fB/sbin/udevd\fR [\fB\-\-daemon\fR] [\fB\-\-debug\fR] [\fB\-\-children\-max=\fR] [\fB\-\-exec\-delay=\fR] [\fB\-\-event\-timeout=\fR] [\fB\-\-resolve\-names=early|late|never\fR] [\fB\-\-version\fR] [\fB\-\-help\fR]
+\fB/sbin/udevd\fR [\fB\-\-daemon\fR] [\fB\-\-debug\fR] [\fB\-\-ready\-notify=\fR] [\fB\-\-children\-max=\fR] [\fB\-\-exec\-delay=\fR] [\fB\-\-event\-timeout=\fR] [\fB\-\-resolve\-names=early|late|never\fR] [\fB\-\-version\fR] [\fB\-\-help\fR]
 .SH "DESCRIPTION"
 .PP
 \fBudevd\fR
@@ -45,6 +45,11 @@ Detach and run in the background\&.
 \fB\-D\fR, \fB\-\-debug\fR
 .RS 4
 Print debug messages to standard error\&.
+.RE
+.PP
+\fB\-r\fR, \fB\-\-ready\-notify=\fR
+.RS 4
+Issue (S6/dinit compatible) readiness notification via a file descriptor\&. A short message followed by a newline character will be sent via the specified file descriptor (inherited from the parent process) when initialization is complete\&.
 .RE
 .PP
 \fB\-c\fR, \fB\-\-children\-max=\fR

--- a/man/udevd.xml
+++ b/man/udevd.xml
@@ -34,6 +34,7 @@
       <command>/sbin/udevd</command>
       <arg><option>--daemon</option></arg>
       <arg><option>--debug</option></arg>
+      <arg><option>--ready-notify=</option></arg>
       <arg><option>--children-max=</option></arg>
       <arg><option>--exec-delay=</option></arg>
       <arg><option>--event-timeout=</option></arg>
@@ -72,6 +73,16 @@
         <term><option>-D</option>, <option>--debug</option></term>
         <listitem>
           <para>Print debug messages to standard error.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>-r</option>, <option>--ready-notify=</option></term>
+        <listitem>
+          <para>Issue (S6/dinit compatible) readiness notification via a
+          file descriptor. A short message followed by a newline character
+          will be sent via the specified file descriptor (inherited from
+          the parent process) when initialization is complete.</para>
         </listitem>
       </varlistentry>
 


### PR DESCRIPTION
Add support for signalling readiness (complete initialization) by sending a message via a file descriptor, provided by the parent process (such as a service manager).

The mechanism is described here:
https://skarnet.org/software/s6/notifywhenup.html